### PR TITLE
Changed shell def to point to python2 binary specifically

### DIFF
--- a/pharos
+++ b/pharos
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Script Name: pharos
 # Script Function:
 #	This is a CUPS backend for the Pharos Remote Printing LPD Server.

--- a/pharos-uninstall
+++ b/pharos-uninstall
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Script Name: pharos-uninstall.py
 # Script Function:
 #	This script will uninstall pharos remote printing from the system.

--- a/pharospopup
+++ b/pharospopup
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Script Name: pharospopup
 # Script Function:
 #	This is the pharospopup server that is run at users login to the desktop GUI session. It receives messages from the pharos CUPS backend and shows a dialog to the users for input

--- a/pharosuninstall.py
+++ b/pharosuninstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Script Name: uninstall-pharos.py
 # Script Function:
 #	This script will uninstall pharos remote printing from the system.

--- a/printerutils.py
+++ b/printerutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Script Name: printerutils.py
 # Script Function:
 #	This script provides utility functions for dealing with print queues

--- a/processutils.py
+++ b/processutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Script Name: processutils.py
 # Script Function:
 #	This script provides utility functions for dealing with processes

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Script Name: setup.py
 # Script Function:
 #	This script will install pharos remote printing on the system.


### PR DESCRIPTION
Since it is unknown if the python symlink points to a python version 3 or python version 2 binary, the path has been changed to use the python2 symlink instead so it points to the latest python2.x binary without modification. 
