### PR TITLE
Fixes issues with installation on Linux distros that do not install CUPS backends to /usr/lib/cups/backends/

### DIFF
--- a/pharos
+++ b/pharos
@@ -67,7 +67,7 @@ def main():
 		sys.stdout.write("network %s \"Unknown\" \"%s\" \n" %(os.path.basename(sys.argv[0]),  __doc__))
 		sys.stdout.flush()
 		sys.exit(CUPS_BACKEND_OK)
-	if len(sys.argv) not in (5,6):
+	if len(sys.argv) not in (6,7):
 		sys.stdout.write("Usage: %s job-id user title copies options [file]\n" % os.path.basename(sys.argv[0]))
 		sys.stdout.flush()
 		logger.error("Wrong number of arguments (%d). Usage %s job-id user" %(len(sys.argv[0]),  sys.argv[0]))
@@ -92,7 +92,7 @@ def main():
 		if s:
 			s.close()
 		logger.error('Could not connect to popup server. Error %s' %message)
-		sys.exit(CUPS_BACKEND_STOP)
+		sys.exit(CUPS_BACKEND_FAILED)
 		
 	s.send('GetPrintJobParameters')
 	data = s.recv(1024)

--- a/pharos
+++ b/pharos
@@ -3,7 +3,7 @@
 # Script Function:
 #	This is a CUPS backend for the Pharos Remote Printing LPD Server.
 # Save this file in your CUPS backend directory, usually
-# /usr/lib/cups/backend/ or /usr/local/lib/cups/backend/
+# /usr/lib/cups/backend/ or /usr/local/lib/cups/backend/ or /usr/libexec/cups/backend/
 #
 # Mark this filter world-readable and world-executable. Restart CUPS to
 # make the new backend known to the spooler.
@@ -56,6 +56,9 @@ CUPS_BACKEND_CANCEL = 5
 # Script Variables ===================================
 programConfigFilePath = '/usr/local/etc/pharos.conf'
 cupsBackendDIR = '/usr/lib/cups/backend'
+
+if not os.path.isdir(cupsBackendDIR):
+        cupsBackendDIR = '/usr/libexec/cups/backend'
 
 # Function Declaration ===============================
 def main():

--- a/pharosuninstall.py
+++ b/pharosuninstall.py
@@ -86,6 +86,10 @@ class PharosUninstaller:
 		"""
 		self.logger.info('Uninstalling pharos backend')
 		backendDIR = '/usr/lib/cups/backend'
+
+                if not os.path.isdir(backendDIR):
+                        backendDIR = '/usr/libexec/cups/backend'
+
 		backendFile = os.path.join(backendDIR, pharosBackendFileName)
 		if os.path.exists(backendFile):
 			self.logger.info('Backend file %s exists. Trying to remove it' %backendFile)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def installBackend():
 	"""
 	Install the pharos backend
 	"""
-	backendDIR = '/usr/libexec/cups/backend'
+	backendDIR = '/usr/lib/cups/backend'
 	backendFile = os.path.join(os.getcwd(), pharosBackendFileName)
 	
 	logger.info('Checking for CUPS backend directory %s' %backendDIR)

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,10 @@ def installBackend():
 	Install the pharos backend
 	"""
 	backendDIR = '/usr/lib/cups/backend'
+
+        if not os.path.isdir(backendDIR):
+                backendDIR = '/usr/libexec/cups/backend'
+
 	backendFile = os.path.join(os.getcwd(), pharosBackendFileName)
 	
 	logger.info('Checking for CUPS backend directory %s' %backendDIR)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def installBackend():
 	"""
 	Install the pharos backend
 	"""
-	backendDIR = '/usr/lib/cups/backend'
+	backendDIR = '/usr/libexec/cups/backend'
 	backendFile = os.path.join(os.getcwd(), pharosBackendFileName)
 	
 	logger.info('Checking for CUPS backend directory %s' %backendDIR)
@@ -112,7 +112,7 @@ def installPopupServer():
 	"""
 	Installs the popup server files
 	"""
-	logger.info('Installing poup server files')
+	logger.info('Installing popup server files')
 	popupExecutable = os.path.join(os.getcwd(), pharosPopupServerFileName)
 	pharosConfig = os.path.join(os.getcwd(),pharosConfigFileName)
 	 
@@ -153,28 +153,33 @@ Comment=Pharos Popup Server
 	logger.info('Getting list of current users')
 	currentUsers = os.listdir('/home')	
 	for user in currentUsers:
-		logger.info('Adding autostart file to user %s' %user)
-		autoStartDIR = os.path.join('/home', user, '.config', 'autostart')
-		logger.info('Checking if directory %s exists' %autoStartDIR)
-		if not os.path.exists(autoStartDIR):
-			logger.info('Creating autostart directory %s' %autoStartDIR)
-			os.makedirs(autoStartDIR)			
-		else:
-			logger.info('Autostart directory %s already exists' %autoStartDIR)
+                # Avoid install failure when regular files exist within /home
+                if not os.path.isdir(os.path.join('/home', user)):
+                        continue
+                # Continue with installation
+                else:
+		        logger.info('Adding autostart file to user %s' %user)
+		        autoStartDIR = os.path.join('/home', user, '.config', 'autostart')
+		        logger.info('Checking if directory %s exists' %autoStartDIR)
+		        if not os.path.exists(autoStartDIR):
+			        logger.info('Creating autostart directory %s' %autoStartDIR)
+			        os.makedirs(autoStartDIR)			
+		        else:
+			        logger.info('Autostart directory %s already exists' %autoStartDIR)
 		
-		if os.path.exists(autoStartDIR):			
-			autoStartFile = os.path.join('/home', user, '.config', 'autostart', 'pharospopup.desktop')
-			# Delete old file if it exists
-			if os.path.exists(autoStartFile):
-				logger.info('Deleted old version of autostart file: %s' %autoStartFile)
-				os.remove(autoStartFile)
-			# create new file
-			autoStartFH = open(autoStartFile, 'w')
-			autoStartFH.write(gnomeAutoStartFile)
-			autoStartFH.close()
-			logger.info('Successfully added autostart for %s user' %user)
-		else:
-			logger.warn('Autostart file %s could not be created' %autoStartFile)
+		        if os.path.exists(autoStartDIR):			
+			        autoStartFile = os.path.join('/home', user, '.config', 'autostart', 'pharospopup.desktop')
+			        # Delete old file if it exists
+			        if os.path.exists(autoStartFile):
+				        logger.info('Deleted old version of autostart file: %s' %autoStartFile)
+				        os.remove(autoStartFile)
+			        # create new file
+			        autoStartFH = open(autoStartFile, 'w')
+			        autoStartFH.write(gnomeAutoStartFile)
+			        autoStartFH.close()
+			        logger.info('Successfully added autostart for %s user' %user)
+		        else:
+			        logger.warn('Autostart file %s could not be created' %autoStartFile)
 	
 	# Update the autostart file for root
 	logger.info('Updating autostart file for root')


### PR DESCRIPTION
Contribution by: Nash Kaminski & Daniel Meves
@nkaminski as second contributor - consult either of us for clarification of this logic  

Overview:
By default, certain distros such as Gentoo (kernel 4.9.0 - test platform) install CUPS backends to /usr/libexec/cups/backends/. This breaks compatibility with the pharos-linux installer. We added a simple check for the existence of the backendDIR before trying this alternate path. Unix file hierarchy standard specifies both lib and libexec as acceptable paths. 

Added similar check for the existence of regular files in /home instead of the needed directories. An example is the existence of /home/.keep/. On the test platform (Gentoo 4.9.0), this path was a file but the installer required that it be a directory. The intended behavior is to skip this loop iteration should the directory not exist.

Line 73 in pharos was edited to allow the correct number of argv indexes (6 or 7). Fix allows compatibility with all currently released versions of CUPS. This bug was discovered when troubleshooting the pharos CUPS backend, following this wiki entry:

https://wiki.debian.org/Dissecting%20and%20Debugging%20the%20CUPS%20Printing%20System#Testing_a_Backend_and_a_Printer

Changed line 98 of pharos because CUPS_BACKEND_STOP unconditionally pauses the print queue. CUPS_BACKEND_FAILED allows CUPS to recover from a temporary error, as defined in the CUPS error policy.

Also fixed a spelling typo on line 119 of setup.py.

Feedback is always welcome. Please consider these changes!